### PR TITLE
Feat: add oauth

### DIFF
--- a/components/piper.yaml
+++ b/components/piper.yaml
@@ -160,3 +160,32 @@ services:
           memory: 4g
         reservations:
           memory: 250m
+
+  oauth:
+    <<: *piper
+    networks:
+      - database
+      - ingress
+    command: ["oauth"]
+    deploy:
+      placement:
+        constraints:
+          -  "node.role==manager"
+      labels:
+        - "traefik.enable=true"
+        - "traefik.http.routers.sockets.entrypoints=http"
+        - "traefik.http.routers.sockets.rule=Host(`${DOMAIN}`) && PathPrefix(`/oauth/`)"
+        - "traefik.http.routers.sockets.middlewares=sockets-strip-oauth"
+        - "traefik.http.middlewares.sockets-strip-oauth.stripprefix.prefixes=/oauth"
+        - "traefik.http.services.sockets.loadbalancer.server.port=80"
+        - "traefik.docker.network=piper_ingress"
+      replicas: 1
+      update_config:
+        parallelism: 1
+        delay: 5s
+        order: start-first
+      resources:
+        limits:
+          memory: 1g
+        reservations:
+          memory: 250m

--- a/config/piper.env.template
+++ b/config/piper.env.template
@@ -5,6 +5,11 @@ MONGO_URL=mongodb://mongo:27017
 REDIS_URL=redis://redis:6379/
 
 STORAGE_BASE_URL=https://xyz.com/storage
+JWT_SECRET=xyzXYZ
 
-PAAS_BASE_URL=https://api.generativecore.ai/api/v3
-PAAS_AUTH=xyzXYZ|xyzXYZ
+# OAuth
+GOOGLE_CLIENT_ID=xyzXYZ
+GOOGLE_CLIENT_SECRET=xyzXYZ
+
+YANDEX_CLIENT_ID=xyzXYZ
+YANDEX_CLIENT_SECRET=xyzXYZ


### PR DESCRIPTION
Please, take a look.

We need rewrite

```
    location /oauth {
        rewrite ^/oauth/(.*)$ /$1 break;
        proxy_pass http://oauth;
    }
```

I tried

```
      labels:
        - "traefik.enable=true"
        - "traefik.http.routers.sockets.entrypoints=http"
        - "traefik.http.routers.sockets.rule=Host(`${DOMAIN}`) && PathPrefix(`/oauth/`)"
        - "traefik.http.routers.sockets.middlewares=sockets-strip-oauth"
        - "traefik.http.middlewares.sockets-strip-oauth.stripprefix.prefixes=/oauth"
        - "traefik.http.services.sockets.loadbalancer.server.port=80"
        - "traefik.docker.network=piper_ingress"
```